### PR TITLE
dhcpcd update and fix service.py

### DIFF
--- a/system/base/dhcpcd/actions.py
+++ b/system/base/dhcpcd/actions.py
@@ -21,11 +21,12 @@ def build():
 
 def install():
     autotools.rawInstall("DESTDIR=%s" % get.installDIR())
+    
     # Set Options in /etc/dhcpcd.conf Disable ip4vall
     shelltools.echo("%s/etc/dhcpcd.conf" % get.installDIR(), "noipv4ll")
+    
     # Remove hooks install the compat one
-    pisitools.remove("/usr/lib/dhcpcd/dhcpcd-hooks/*")
-    pisitools.insinto("/usr/lib/dhcpcd/dhcpcd-hooks", "dhcpcd-hooks/50-dhcpcd-compat")
+    #pisitools.remove("/usr/lib/dhcpcd/dhcpcd-hooks/*")
+    #pisitools.insinto("/usr/lib/dhcpcd/dhcpcd-hooks", "dhcpcd-hooks/50-dhcpcd-compat")
 
-    pisitools.dodoc("README")
-#DBDIR=/var/lib/dhcpcd LIBEXECDIR=/usr/lib/dhcpcd
+    pisitools.dodoc("README.md")

--- a/system/base/dhcpcd/comar/service.py
+++ b/system/base/dhcpcd/comar/service.py
@@ -21,7 +21,7 @@ def start():
         fail(MSG_BACKEND_WARNING)
 
     startService(command="/usr/bin/dhcpcd",
-                 args="daemon -q -b %s" % pidfile,
+                 args="-q ",
                  donotify=True)
 
 @synchronized

--- a/system/base/dhcpcd/files/dhcpcd-7.1.1-disable_inet6_fix.patch
+++ b/system/base/dhcpcd/files/dhcpcd-7.1.1-disable_inet6_fix.patch
@@ -1,0 +1,24 @@
+From 6db54edd1427823dcb3924be78c042915a825fb1 Mon Sep 17 00:00:00 2001
+From: Chris Clayton <chris2553@googlemail.com>
+Date: Fri, 8 Feb 2019 16:35:36 +0000
+Subject: fix build with --disable-inet6
+
+---
+ src/dhcpcd.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/dhcpcd.c b/src/dhcpcd.c
+index a2cd04e..6fe60ea 100644
+--- a/src/dhcpcd.c
++++ b/src/dhcpcd.c
+@@ -54,6 +54,7 @@ const char dhcpcd_copyright[] = "Copyright (c) 2006-2019 Roy Marples";
+ #include "dev.h"
+ #include "dhcp-common.h"
+ #include "dhcpcd.h"
++#include "dhcp.h"
+ #include "dhcp6.h"
+ #include "duid.h"
+ #include "eloop.h"
+-- 
+cgit v1.1
+

--- a/system/base/dhcpcd/files/dhcpcd-7.1.1-overflows.patch
+++ b/system/base/dhcpcd/files/dhcpcd-7.1.1-overflows.patch
@@ -1,0 +1,213 @@
+https://roy.marples.name/git/dhcpcd.git/patch/?id=23525884a346ed81c808c1ed90e3c56a8bf0cc68
+
+From 8d11b33f6c60e2db257130fa383ba76b6018bcf6 Mon Sep 17 00:00:00 2001
+From: Roy Marples <roy@marples.name>
+Date: Fri, 19 Apr 2019 09:45:02 +0100
+Subject: DHCPv6: Fix a potential buffer overflow reading NA/TA addresses
+
+Only copy upto the size of the address option rather than the
+option length.
+
+Found by Maxime Villard <max@m00nbsd.net>
+---
+ src/dhcp6.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/dhcp6.c b/src/dhcp6.c
+index 99a452b..8fc4f00 100644
+--- a/src/dhcp6.c
++++ b/src/dhcp6.c
+@@ -2029,12 +2029,12 @@ dhcp6_findna(struct interface *ifp, uint16_t ot, const uint8_t *iaid,
+ 		nd = o + ol;
+ 		l -= (size_t)(nd - d);
+ 		d = nd;
+-		if (ol < 24) {
++		if (ol < sizeof(ia)) {
+ 			errno = EINVAL;
+ 			logerrx("%s: IA Address option truncated", ifp->name);
+ 			continue;
+ 		}
+-		memcpy(&ia, o, ol);
++		memcpy(&ia, o, sizeof(ia));
+ 		ia.pltime = ntohl(ia.pltime);
+ 		ia.vltime = ntohl(ia.vltime);
+ 		/* RFC 3315 22.6 */
+-- 
+cgit v1.1
+
+
+From 4b67f6f1038fd4ad5ca7734eaaeba1b2ec4816b8 Mon Sep 17 00:00:00 2001
+From: Roy Marples <roy@marples.name>
+Date: Fri, 19 Apr 2019 21:00:19 +0100
+Subject: DHCP: Fix a potential 1 byte read overflow with DHO_OPTSOVERLOADED
+
+This fix basically moves the option length check up and also
+corrects an off by one error with it.
+
+Thanks to Maxime Villard <max@m00nbsd.net>
+---
+ src/dhcp.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/dhcp.c b/src/dhcp.c
+index f7cdefc..e13d1b4 100644
+--- a/src/dhcp.c
++++ b/src/dhcp.c
+@@ -215,6 +215,12 @@ get_option(struct dhcpcd_ctx *ctx,
+ 		}
+ 		l = *p++;
+ 
++		/* Check we can read the option data, if present */
++		if (p + l > e) {
++			errno = EINVAL;
++			return NULL;
++		}
++
+ 		if (o == DHO_OPTSOVERLOADED) {
+ 			/* Ensure we only get this option once by setting
+ 			 * the last bit as well as the value.
+@@ -249,10 +255,6 @@ get_option(struct dhcpcd_ctx *ctx,
+ 				bp += ol;
+ 			}
+ 			ol = l;
+-			if (p + ol >= e) {
+-				errno = EINVAL;
+-				return NULL;
+-			}
+ 			op = p;
+ 			bl += ol;
+ 		}
+-- 
+cgit v1.1
+
+
+From 7121040790b611ca3fbc400a1bbcd4364ef57233 Mon Sep 17 00:00:00 2001
+From: Roy Marples <roy@marples.name>
+Date: Fri, 19 Apr 2019 21:40:14 +0100
+Subject: auth: Use consttime_memequal(3) to compare hashes
+
+This stops any attacker from trying to infer secrets from latency.
+
+Thanks to Maxime Villard <max@m00nbsd.net>
+---
+ src/auth.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/auth.c b/src/auth.c
+index 9e24998..ce97051 100644
+--- a/src/auth.c
++++ b/src/auth.c
+@@ -354,7 +354,7 @@ gottoken:
+ 	}
+ 
+ 	free(mm);
+-	if (memcmp(d, &hmac_code, dlen)) {
++	if (!consttime_memequal(d, &hmac_code, dlen)) {
+ 		errno = EPERM;
+ 		return NULL;
+ 	}
+-- 
+cgit v1.1
+
+
+From cfde89ab66cb4e5957b1c4b68ad6a9449e2784da Mon Sep 17 00:00:00 2001
+From: Roy Marples <roy@marples.name>
+Date: Fri, 19 Apr 2019 21:42:07 +0100
+Subject: compat: Provide consttime_memequal if not in libc
+
+Public domain version by Matthias Drochner <drochner@netbsd.org>
+---
+ configure | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/configure b/configure
+index 570e65f..4f58f0f 100755
+--- a/configure
++++ b/configure
+@@ -13,6 +13,7 @@ IPV4LL=
+ INET6=
+ ARC4RANDOM=
+ CLOSEFROM=
++CONSTTIME_MEMEQUAL=
+ STRLCPY=
+ UDEV=
+ OS=
+@@ -846,6 +847,27 @@ if [ "$STRTOI" = no ]; then
+ 	echo "#include			\"compat/strtoi.h\"" >>$CONFIG_H
+ fi
+ 
++if [ -z "$CONSTTIME_MEMEQUAL" ]; then
++	printf "Testing for consttime_memequal ... "
++	cat <<EOF >_consttime_memequal.c
++#include <string.h>
++int main(void) {
++	return consttime_memequal("deadbeef", "deadbeef", 8);
++}
++EOF
++	if $XCC _consttime_memequal.c -o _consttime_memequal 2>&3; then
++		CONSTTIME_MEMEQUAL=yes
++	else
++		CONSTTIME_MEMEQUAL=no
++	fi
++	echo "$CONSTTIME_MEMEQUAL"
++	rm -f _consttime_memequal.c _consttime_memequal
++fi
++if [ "$CONSTTIME_MEMEQUAL" = no ]; then
++	echo "#include			\"compat/consttime_memequal.h\"" \
++	    >>$CONFIG_H
++fi
++
+ if [ -z "$DPRINTF" ]; then
+ 	printf "Testing for dprintf ... "
+ 	cat <<EOF >_dprintf.c
+-- 
+cgit v1.1
+
+
+From aee631aadeef4283c8a749c1caf77823304acf5e Mon Sep 17 00:00:00 2001
+From: Roy Marples <roy@marples.name>
+Date: Fri, 19 Apr 2019 21:47:37 +0100
+Subject: Really add consttime_memequal
+
+---
+ compat/consttime_memequal.h | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+ create mode 100644 compat/consttime_memequal.h
+
+diff --git a/compat/consttime_memequal.h b/compat/consttime_memequal.h
+new file mode 100644
+index 0000000..9830648
+--- /dev/null
++++ b/compat/consttime_memequal.h
+@@ -0,0 +1,28 @@
++/*
++ * Written by Matthias Drochner <drochner@NetBSD.org>.
++ * Public domain.
++ */
++
++#ifndef CONSTTIME_MEMEQUAL_H
++#define CONSTTIME_MEMEQUAL_H
++inline static int
++consttime_memequal(const void *b1, const void *b2, size_t len)
++{
++	const unsigned char *c1 = b1, *c2 = b2;
++	unsigned int res = 0;
++
++	while (len--)
++		res |= *c1++ ^ *c2++;
++
++	/*
++	 * Map 0 to 1 and [1, 256) to 0 using only constant-time
++	 * arithmetic.
++	 *
++	 * This is not simply `!res' because although many CPUs support
++	 * branchless conditional moves and many compilers will take
++	 * advantage of them, certain compilers generate branches on
++	 * certain CPUs for `!res'.
++	 */
++	return (1 & ((res - 1) >> 8));
++}
++#endif /* CONSTTIME_MEMEQUAL_H */
+-- 
+cgit v1.1
+

--- a/system/base/dhcpcd/files/dhcpcd-7.1.1-v6_read_overflow.patch
+++ b/system/base/dhcpcd/files/dhcpcd-7.1.1-v6_read_overflow.patch
@@ -1,0 +1,120 @@
+From c1ebeaafeb324bac997984abdcee2d4e8b61a8a8 Mon Sep 17 00:00:00 2001
+From: Roy Marples <roy@marples.name>
+Date: Fri, 3 May 2019 14:44:06 +0100
+Subject: DHCPv6: Fix a potential read overflow with D6_OPTION_PD_EXCLUDE
+
+dhcpcd only checks that the prefix length of the exclusion
+matches the prefix length of the ia and equals the length of the
+data in the option.
+This could potentially overrun the in6_addr structure.
+
+This is fixed by enforcing RFC 6603 section 4.2 option limits
+more clearly.
+
+Thanks to Maxime Villard <max@m00nbsd.net> for finding this.
+---
+ src/dhcp6.c | 44 +++++++++++++++++++++-----------------------
+ 1 file changed, 21 insertions(+), 23 deletions(-)
+
+diff --git a/src/dhcp6.c b/src/dhcp6.c
+index dee8d4b6..583f3b3f 100644
+--- a/src/dhcp6.c
++++ b/src/dhcp6.c
+@@ -2166,40 +2166,38 @@ dhcp6_findpd(struct interface *ifp, const uint8_t *iaid,
+ 			state->expire = a->prefix_vltime;
+ 		i++;
+ 
+-		o = dhcp6_findoption(o, ol, D6_OPTION_PD_EXCLUDE, &ol);
+ 		a->prefix_exclude_len = 0;
+ 		memset(&a->prefix_exclude, 0, sizeof(a->prefix_exclude));
+-#if 0
+-		if (ex == NULL) {
+-			struct dhcp6_option *w;
+-			uint8_t *wp;
+-
+-			w = calloc(1, 128);
+-			w->len = htons(2);
+-			wp = D6_OPTION_DATA(w);
+-			*wp++ = 64;
+-			*wp++ = 0x78;
+-			ex = w;
+-		}
+-#endif
++		o = dhcp6_findoption(o, ol, D6_OPTION_PD_EXCLUDE, &ol);
+ 		if (o == NULL)
+ 			continue;
+-		if (ol < 2) {
+-			logerrx("%s: truncated PD Exclude", ifp->name);
++
++		/* RFC 6603 4.2 says option length MUST be between 2 and 17.
++		 * This allows 1 octet for prefix length and 16 for the
++		 * subnet ID. */
++		if (ol < 2 || ol > 17) {
++			logerrx("%s: invalid PD Exclude option", ifp->name);
+ 			continue;
+ 		}
+-		a->prefix_exclude_len = *o++;
+-		ol--;
+-		if (((a->prefix_exclude_len - a->prefix_len - 1) / NBBY) + 1
+-		    != ol)
+-		{
++
++		/* RFC 6603 4.2 says prefix length MUST be between the
++		 * length of the IAPREFIX prefix length + 1 and 128. */
++		if (*o < a->prefix_len + 1 || *o > 128) {
++			logerrx("%s: invalid PD Exclude length", ifp->name);
++			continue;
++		}
++
++		/* Check option length matches prefix length. */
++		if (((*o - a->prefix_len - 1) / NBBY) + 1 != ol) {
+ 			logerrx("%s: PD Exclude length mismatch", ifp->name);
+-			a->prefix_exclude_len = 0;
+ 			continue;
+ 		}
+-		nb = a->prefix_len % NBBY;
++
++		a->prefix_exclude_len = *o++;
++		ol--;
+ 		memcpy(&a->prefix_exclude, &a->prefix,
+ 		    sizeof(a->prefix_exclude));
++		nb = a->prefix_len % NBBY;
+ 		if (nb)
+ 			ol--;
+ 		pw = a->prefix_exclude.s6_addr +
+-- 
+cgit v1.2.1
+
+From 896ef4a54b0578985e5e1360b141593f1d62837b Mon Sep 17 00:00:00 2001
+From: Roy Marples <roy@marples.name>
+Date: Sat, 4 May 2019 10:19:02 +0100
+Subject: DHCPv6: Fix exclude prefix length check.
+
+---
+ src/dhcp6.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/dhcp6.c b/src/dhcp6.c
+index 583f3b3f..7f26129f 100644
+--- a/src/dhcp6.c
++++ b/src/dhcp6.c
+@@ -2187,14 +2187,14 @@ dhcp6_findpd(struct interface *ifp, const uint8_t *iaid,
+ 			continue;
+ 		}
+ 
++		ol--;
+ 		/* Check option length matches prefix length. */
+ 		if (((*o - a->prefix_len - 1) / NBBY) + 1 != ol) {
+ 			logerrx("%s: PD Exclude length mismatch", ifp->name);
+ 			continue;
+ 		}
+-
+ 		a->prefix_exclude_len = *o++;
+-		ol--;
++
+ 		memcpy(&a->prefix_exclude, &a->prefix,
+ 		    sizeof(a->prefix_exclude));
+ 		nb = a->prefix_len % NBBY;
+-- 
+cgit v1.2.1
+

--- a/system/base/dhcpcd/pspec.xml
+++ b/system/base/dhcpcd/pspec.xml
@@ -12,7 +12,12 @@
         <IsA>app:console</IsA>
         <Summary>A dhcp client only</Summary>
         <Description>An RFC2131 and RFC1541 compliant DHCP client daemon. dhcpcd gets an IP address and other information from a corresponding DHCP server, configures the network interface automatically, and tries to renew the lease time according to RFC2131 or RFC1541 depending on the command line option.</Description>
-        <Archive sha1sum="aa0a97682cb7dad3ea0acfe623a67da42614a2d8" type="tarxz">http://ftp.osuosl.org/pub/blfs/conglomeration/dhcpcd/dhcpcd-6.11.5.tar.xz</Archive>
+        <Archive sha1sum="c17c0797672d40758d784ba7e3fbdc12552bd0fc" type="tarxz">http://ftp.osuosl.org/pub/blfs/conglomeration/dhcpcd/dhcpcd-7.1.1.tar.xz</Archive>
+        <Patches>
+            <Patch>dhcpcd-7.1.1-disable_inet6_fix.patch</Patch>
+            <Patch>dhcpcd-7.1.1-overflows.patch</Patch>
+            <Patch>dhcpcd-7.1.1-v6_read_overflow.patch</Patch>
+        </Patches>
         <BuildDependencies>
             <Dependency>eudev-devel</Dependency>
         </BuildDependencies>
@@ -40,6 +45,13 @@
     </Package>
 
     <History>
+        <Update release="5">
+            <Date>2019-06-02</Date>
+            <Version>7.1.1</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Ertuğrul Erata</Name>
+            <Email>ertugrulerata@gmail.com</Email>
+        </Update>
         <Update release="4">
             <Date>2018-07-15</Date>
             <Version>6.11.5</Version>


### PR DESCRIPTION
for fix trace.log
```
2019-06-03 10:10:26 (559) [bus:1.16] ERROR: Exception: Exception - Unable to start service.
2019-06-03 10:10:26 (559) [bus:1.16] ERROR:     File /var/db/comar3/scripts/System.Service/dhcpcd.py, line 41, in ready()
2019-06-03 10:10:26 (559) [bus:1.16] ERROR:     File /usr/lib/pisilinux/comar/utility.py, line 36, in handler()
2019-06-03 10:10:26 (559) [bus:1.16] ERROR:     File /var/db/comar3/scripts/System.Service/dhcpcd.py, line 25, in start()
2019-06-03 10:10:26 (559) [bus:1.16] ERROR:     File /usr/lib/pisilinux/comar/service.py, line 281, in startService()
```
dhcpcd.pid oluşmadığı için servisin durumu anlaşılmıyordu. ayrıca durdurma işlemi de uygun çalışmıyordu.