### PR TITLE
Uprev curl

### DIFF
--- a/system/base/curl/pspec.xml
+++ b/system/base/curl/pspec.xml
@@ -14,7 +14,7 @@
         <IsA>library</IsA>
         <Summary>A utility for getting files from remote servers</Summary>
         <Description>curl is a command line tool for transferring data with URL syntax, supporting various protocols.</Description>
-        <Archive sha1sum="4e597422c965c5f3cc0aff64cbfe6ef58e65e46f" type="tarbz2">http://curl.haxx.se/download/curl-8.11.0.tar.bz2</Archive>
+        <Archive sha1sum="97247fefb1ae983c453ebe5bb17b573862e493eb" type="tarbz2">https://github.com/curl/curl/releases/download/curl-8_11_1/curl-8.11.1.tar.bz2</Archive>
         <BuildDependencies>
             <Dependency>glibc-devel</Dependency>
             <Dependency>zstd-devel</Dependency>
@@ -74,6 +74,13 @@
     </Package>
 
     <History>
+        <Update release="19">
+            <Date>2025-01-01</Date>
+            <Version>8.11.1</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Bedirhan KURT</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="18">
             <Date>2024-12-16</Date>
             <Version>8.11.0</Version>


### PR DESCRIPTION
Also change the URL we grab the release from to GitHub since that's the fastest ever resource we'll be able to grab it.