### PR TITLE
Fix download for wireless-tools source code

### DIFF
--- a/system/base/wireless-tools/pspec.xml
+++ b/system/base/wireless-tools/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>app:console</IsA>
         <Summary>A collection of tools to configure wireless lan cards</Summary>
         <Description>The Wireless Tools (WT) is a set of tools allowing to manipulate the Wireless Extensions, a generic application programming interface allowing a driver to expose to the user space configuration and statistics specific to common Wireless LANs. They use a textual interface and are rather crude, but aim to support the full Wireless Extension.</Description>
-        <Archive sha1sum="41db5ced9ed3d8d3cc104ce43c19af1d72f07eec" type="targz">http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/wireless_tools.30.pre9.tar.gz</Archive>
+        <Archive sha1sum="41db5ced9ed3d8d3cc104ce43c19af1d72f07eec" type="targz">https://hewlettpackard.github.io/wireless-tools/wireless_tools.30.pre9.tar.gz</Archive>
         <Patches>
             <Patch>no-ldconfig.patch</Patch>
             <Patch level="0">wireless_tools.27-wireless-man-upd.patch</Patch>
@@ -50,6 +50,13 @@
     </Package>
 
     <History>
+        <Update release="7">
+            <Date>2025-10-08</Date>
+            <Version>30</Version>
+            <Comment>Make it buildable again</Comment>
+            <Name>Bedirhan Kurt</Name>
+            <Email>bedirhan.kurt@outlook.com</Email>
+        </Update>
         <Update release="6">
             <Date>2020-12-09</Date>
             <Version>30</Version>


### PR DESCRIPTION
HP changed where it's stored.
